### PR TITLE
Adds require dotenv to next.config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .env.build
 node_modules
+package-lock.json

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 module.exports = {
   env: {
     DEMO_KEY: process.env.DEMO_KEY

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "now-build": "next build && echo $DEMO_KEY"
   },
   "dependencies": {
+    "dotenv": "^8.2.0",
     "next": "^9.0.5",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
Thanks for making this tutorial @leighhalliday. As I was setting it up I realized that it was necessary to add 'dotenv' as a dependency and require it in next.config.js similar to [this with-dotenv example](https://github.com/zeit/next.js/tree/canary/examples/with-dotenv). Hopefully this can save others some troubleshooting.